### PR TITLE
cred scan for provider block

### DIFF
--- a/commands/credential_scan.go
+++ b/commands/credential_scan.go
@@ -17,23 +17,23 @@ import (
 )
 
 type CredentialScanCommand struct {
-	workingDir  string
-	swaggerPath string
-	verbose     bool
+	workingDir      string
+	swaggerRepoPath string
+	verbose         bool
 }
 
 func (c *CredentialScanCommand) flags() *flag.FlagSet {
 	fs := defaultFlagSet("test")
 	fs.BoolVar(&c.verbose, "v", false, "whether show terraform logs")
 	fs.StringVar(&c.workingDir, "working-dir", "", "path to Terraform configuration files")
-	fs.StringVar(&c.swaggerPath, "swagger", "", "path to the swagger repo specification directory")
+	fs.StringVar(&c.swaggerRepoPath, "swagger-repo", "", "path to the swagger repo specification directory")
 	fs.Usage = func() { logrus.Error(c.Help()) }
 	return fs
 }
 
 func (c CredentialScanCommand) Help() string {
 	helpText := `
-Usage: armstrong credscan [-v] [-working-dir <path to directory containing Terraform configuration files>] [-swagger <path to the swagger repo specification directory>]
+Usage: armstrong credscan [-v] [-working-dir <path to directory containing Terraform configuration files>] [-swagger-repo <path to the swagger repo specification directory>]
 ` + c.Synopsis() + "\n\n" + helpForFlags(c.flags())
 
 	return strings.TrimSpace(helpText)
@@ -70,22 +70,26 @@ func (c CredentialScanCommand) Execute() int {
 			return 1
 		}
 	}
-	if c.swaggerPath != "" {
-		c.swaggerPath, err = filepath.Abs(c.swaggerPath)
+	if c.swaggerRepoPath != "" {
+		c.swaggerRepoPath, err = filepath.Abs(c.swaggerRepoPath)
 		if err != nil {
-			logrus.Errorf("swagger path %q is invalid: %+v", c.swaggerPath, err)
+			logrus.Errorf("swagger repo path %q is invalid: %+v", c.swaggerRepoPath, err)
 			return 1
 		}
 
-		if _, err := os.Stat(c.swaggerPath); os.IsNotExist(err) {
-			logrus.Errorf("swagger path %q is invalid: path does not exist", c.swaggerPath)
+		if _, err := os.Stat(c.swaggerRepoPath); os.IsNotExist(err) {
+			logrus.Errorf("swagger repo path %q is invalid: path does not exist", c.swaggerRepoPath)
 			return 1
 		}
 
-		if !strings.HasSuffix(c.swaggerPath, "specification") {
-			logrus.Errorf("swagger path %q is invalid: must point to \"specification\", e.g., /home/projects/azure-rest-api-specs/specification", c.swaggerPath)
+		c.swaggerRepoPath = strings.TrimSuffix(c.swaggerRepoPath, "/")
+
+		if !strings.HasSuffix(c.swaggerRepoPath, "specification") {
+			logrus.Errorf("swagger repo path %q is invalid: must point to \"specification\", e.g., /home/projects/azure-rest-api-specs/specification", c.swaggerRepoPath)
 			return 1
 		}
+
+		c.swaggerRepoPath += "/"
 	}
 
 	tfFiles, err := hcl.FindTfFiles(wd)
@@ -94,12 +98,13 @@ func (c CredentialScanCommand) Execute() int {
 		return 1
 	}
 	if len(*tfFiles) == 0 {
-		logrus.Warnf("no .tf file found in %q", wd)
+		logrus.Warnf("no tf file found in %q", wd)
 	}
-	logrus.Infof("find %v .tf files under %s", len(*tfFiles), wd)
+	logrus.Infof("find %v tf file(s) under %s", len(*tfFiles), wd)
 
 	azapiResources := make([]hcl.AzapiResource, 0)
 	vars := make(map[string]hcl.Variable, 0)
+	azureProviders := make([]hcl.AzureProvider, 0)
 	for _, tfFile := range *tfFiles {
 		f, err := hcl.ParseHclFile(tfFile)
 		if err != nil {
@@ -123,9 +128,62 @@ func (c CredentialScanCommand) Execute() int {
 		for k, v := range *varsInFile {
 			vars[k] = v
 		}
+
+		azureProvidersInFile, err := hcl.ParseAzureProvider(*f)
+		if err != nil {
+			logrus.Errorf("failed to parse azure provider for %q: %+v", tfFile, err)
+			return 1
+		}
+		azureProviders = append(azureProviders, *azureProvidersInFile...)
+
 	}
 
 	credScanErrors := make([]CredScanError, 0)
+
+	for _, azureProvider := range azureProviders {
+		if v := azureProvider.SubscriptionId; v != "" {
+			credScanErrors = append(credScanErrors, checkAzureProviderSecret(azureProvider, "subscription_id", v, vars)...)
+		}
+
+		if v := azureProvider.TenantId; v != "" {
+			credScanErrors = append(credScanErrors, checkAzureProviderSecret(azureProvider, "tenant_id", v, vars)...)
+		}
+
+		if v := azureProvider.AuxiliaryTenantIds; len(v) > 0 {
+			for i, tenant_id := range v {
+				credScanErrors = append(credScanErrors, checkAzureProviderSecret(azureProvider, fmt.Sprintf("auxiliary_tenant_ids[%v]", i), tenant_id, vars)...)
+			}
+		}
+
+		if v := azureProvider.AuxiliaryTenantIdsString; v != "" {
+			credScanErrors = append(credScanErrors, checkAzureProviderSecret(azureProvider, "auxiliary_tenant_ids", v, vars)...)
+		}
+
+		if v := azureProvider.ClientId; v != "" {
+			credScanErrors = append(credScanErrors, checkAzureProviderSecret(azureProvider, "client_id", v, vars)...)
+		}
+
+		if v := azureProvider.ClientCertificate; v != "" {
+			credScanErrors = append(credScanErrors, checkAzureProviderSecret(azureProvider, "client_certificate", v, vars)...)
+		}
+
+		if v := azureProvider.ClientCertificatePassword; v != "" {
+			credScanErrors = append(credScanErrors, checkAzureProviderSecret(azureProvider, "client_certificate_password", v, vars)...)
+		}
+
+		if v := azureProvider.ClientSecret; v != "" {
+			credScanErrors = append(credScanErrors, checkAzureProviderSecret(azureProvider, "client_secret", v, vars)...)
+		}
+
+		if v := azureProvider.OidcRequestToken; v != "" {
+			credScanErrors = append(credScanErrors, checkAzureProviderSecret(azureProvider, "oidc_request_token", v, vars)...)
+		}
+
+		if v := azureProvider.OidcToken; v != "" {
+			credScanErrors = append(credScanErrors, checkAzureProviderSecret(azureProvider, "oidc_token", v, vars)...)
+		}
+
+	}
 
 	for _, azapiResource := range azapiResources {
 		logrus.Infof("scaning azapi_resource.%s(%s)", azapiResource.Name, azapiResource.Type)
@@ -143,7 +201,6 @@ func (c CredentialScanCommand) Execute() int {
 			)
 			credScanErrors = append(credScanErrors, credScanErr)
 			logrus.Error(credScanErr)
-
 			continue
 		}
 
@@ -151,9 +208,9 @@ func (c CredentialScanCommand) Execute() int {
 		logrus.Infof("azapi_resource.%s(%s): mocked possible resource ID: %s, API version: %s", azapiResource.Name, azapiResource.Type, mockedResourceId, apiVersion)
 
 		var swaggerModel *coverage.SwaggerModel
-		if c.swaggerPath != "" {
-			logrus.Infof("scan based on local swagger file: %s", c.swaggerPath)
-			swaggerModel, err = coverage.GetModelInfoFromLocalIndex(mockedResourceId, apiVersion, c.swaggerPath)
+		if c.swaggerRepoPath != "" {
+			logrus.Infof("scan based on local swagger repo: %s", c.swaggerRepoPath)
+			swaggerModel, err = coverage.GetModelInfoFromLocalIndex(mockedResourceId, apiVersion, c.swaggerRepoPath)
 			if err != nil {
 				credScanErr := makeCredScanError(
 					azapiResource,
@@ -240,10 +297,10 @@ func (c CredentialScanCommand) Execute() int {
 				continue
 			}
 
-			if theVar.Default != "" {
+			if theVar.HasDefault {
 				credScanErr := makeCredScanError(
 					azapiResource,
-					fmt.Sprintf("variable %q used in secret field but has a default value, please remove the default value", varName),
+					fmt.Sprintf("variable %q (%v:%v) used in secret field but has a default value, please remove the default value", varName, theVar.FileName, theVar.LineNumber),
 					k,
 				)
 				credScanErrors = append(credScanErrors, credScanErr)
@@ -253,7 +310,7 @@ func (c CredentialScanCommand) Execute() int {
 			if !theVar.IsSensitive {
 				credScanErr := makeCredScanError(
 					azapiResource,
-					fmt.Sprintf("variable %q used in secret field but is not marked as sensitive, please add \"sensitive: true\" for the variable", varName),
+					fmt.Sprintf("variable %q (%v:%v) used in secret field but is not marked as sensitive, please add \"sensitive=true\" for the variable", varName, theVar.FileName, theVar.LineNumber),
 					k,
 				)
 				credScanErrors = append(credScanErrors, credScanErr)
@@ -269,31 +326,47 @@ func (c CredentialScanCommand) Execute() int {
 
 type CredScanError struct {
 	FileName     string `json:"file_name"`
-	ResourceName string `json:"resource_name"`
-	ResourceType string `json:"resource_type"`
+	Name         string `json:"name"`
+	Type         string `json:"type"`
 	PropertyName string `json:"property_name"`
 	ErrorMessage string `json:"error_message"`
 	LineNumber   int    `json:"line_number"`
 }
 
-func makeCredScanError(azapiResource hcl.AzapiResource, errMessage string, PropertyName string) CredScanError {
+func makeCredScanError(azapiResource hcl.AzapiResource, errMessage, propertyName string) CredScanError {
 	result := CredScanError{
 		FileName:     azapiResource.FileName,
 		LineNumber:   azapiResource.LineNumber,
-		ResourceName: fmt.Sprintf("azapi_resource.%s", azapiResource.Name),
-		ResourceType: azapiResource.Type,
+		Name:         fmt.Sprintf("azapi_resource.%s", azapiResource.Name),
+		Type:         azapiResource.Type,
 		ErrorMessage: errMessage,
 	}
 
-	if PropertyName != "" {
-		result.PropertyName = PropertyName
+	if propertyName != "" {
+		result.PropertyName = propertyName
+	}
+
+	return result
+}
+
+func makeCredScanErrorForProvider(azureProvider hcl.AzureProvider, errMessage, propertyName string) CredScanError {
+	result := CredScanError{
+		FileName:     azureProvider.FileName,
+		LineNumber:   azureProvider.LineNumber,
+		Name:         azureProvider.Name(),
+		Type:         "provider",
+		ErrorMessage: errMessage,
+	}
+
+	if propertyName != "" {
+		result.PropertyName = propertyName
 	}
 
 	return result
 }
 
 func (e CredScanError) Error() string {
-	return fmt.Sprintf("%s:%d %s(%s) --%s: %s", e.FileName, e.LineNumber, e.ResourceName, e.ResourceType, e.PropertyName, e.ErrorMessage)
+	return fmt.Sprintf("%s:%d %s(%s) --%s: %s", e.FileName, e.LineNumber, e.Name, e.Type, e.PropertyName, e.ErrorMessage)
 }
 
 func storeCredScanErrors(wd string, credScanErrors []CredScanError) {
@@ -309,11 +382,11 @@ func storeCredScanErrors(wd string, credScanErrors []CredScanError) {
 
 	markdownFileName := "errors.md"
 	credScanErrorsMarkdown := `
-| File Name | Line Number | Resource Name | Resource Type | Property Name | Error Message |
+| File Name | Line Number | Name | Type | Property Name | Error Message |
 | --- | --- | --- | --- | --- | --- |
 `
 	for _, r := range credScanErrors {
-		credScanErrorsMarkdown += fmt.Sprintf("| %s | %d | %s | %s | %s | %s |\n", r.FileName, r.LineNumber, r.ResourceName, r.ResourceType, r.PropertyName, r.ErrorMessage)
+		credScanErrorsMarkdown += fmt.Sprintf("| %s | %d | %s | %s | %s | %s |\n", r.FileName, r.LineNumber, r.Name, r.Type, r.PropertyName, r.ErrorMessage)
 	}
 
 	err = os.WriteFile(path.Join(reportDir, markdownFileName), []byte(credScanErrorsMarkdown), 0644)
@@ -335,4 +408,57 @@ func storeCredScanErrors(wd string, credScanErrors []CredScanError) {
 	} else {
 		logrus.Infof("json report saved to %s", jsonFileName)
 	}
+}
+
+func checkAzureProviderSecret(azureProvider hcl.AzureProvider, propertyName, propertyValue string, vars map[string]hcl.Variable) []CredScanError {
+	credScanErrors := make([]CredScanError, 0)
+
+	if !strings.HasPrefix(propertyValue, "$var.") {
+		credScanErr := makeCredScanErrorForProvider(
+			azureProvider,
+			"must use variable for secret field",
+			propertyName,
+		)
+		credScanErrors = append(credScanErrors, credScanErr)
+		logrus.Error(credScanErr)
+
+		return credScanErrors
+	}
+
+	varName := strings.TrimPrefix(propertyValue, "$var.")
+	varName = strings.Split(varName, ".")[0]
+	theVar, ok := vars[varName]
+	if !ok {
+		credScanErr := makeCredScanErrorForProvider(
+			azureProvider,
+			fmt.Sprintf("variable %q was not found", varName),
+			propertyName,
+		)
+		credScanErrors = append(credScanErrors, credScanErr)
+		logrus.Error(credScanErr)
+
+		return credScanErrors
+	}
+
+	if theVar.HasDefault {
+		credScanErr := makeCredScanErrorForProvider(
+			azureProvider,
+			fmt.Sprintf("variable %q (%v:%v) used in secret field but has a default value, please remove the default value", varName, theVar.FileName, theVar.LineNumber),
+			propertyName,
+		)
+		credScanErrors = append(credScanErrors, credScanErr)
+		logrus.Error(credScanErr)
+	}
+
+	if !theVar.IsSensitive {
+		credScanErr := makeCredScanErrorForProvider(
+			azureProvider,
+			fmt.Sprintf("variable %q (%v:%v) used in secret field but is not marked as sensitive, please add \"sensitive=true\" for the variable", varName, theVar.FileName, theVar.LineNumber),
+			propertyName,
+		)
+		credScanErrors = append(credScanErrors, credScanErr)
+		logrus.Error(credScanErr)
+	}
+
+	return credScanErrors
 }

--- a/coverage/index_test.go
+++ b/coverage/index_test.go
@@ -1,6 +1,8 @@
 package coverage_test
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/ms-henglu/armstrong/coverage"
@@ -81,5 +83,37 @@ func TestGetModelInfoFromIndexWithType_DeviceSecurityGroups(t *testing.T) {
 	expectedApiPath := "/{resourceId}/providers/Microsoft.Security/deviceSecurityGroups/{deviceSecurityGroupName}"
 	if swaggerModel.ApiPath != expectedApiPath {
 		t.Fatalf("expected apiPath %s, got %s", expectedApiPath, swaggerModel.ApiPath)
+	}
+}
+
+func TestGetModelInfoFromLocalIndex_DataCollectionRule(t *testing.T) {
+	azureRepoDir := os.Getenv("AZURE_REST_REPO_DIR")
+	if azureRepoDir == "" {
+		t.Skip("AZURE_REST_REPO_DIR is not set")
+	}
+
+	apiVersion := "2022-06-01"
+	swaggerModel, err := coverage.GetModelInfoFromLocalIndex(
+		"/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-resources/providers/Microsoft.Insights/dataCollectionRules/testDCR",
+		apiVersion,
+		azureRepoDir,
+	)
+	if err != nil {
+		t.Fatalf("get model info from index error: %+v", err)
+	}
+
+	expectedApiPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Insights/dataCollectionRules/{dataCollectionRuleName}"
+	if swaggerModel.ApiPath != expectedApiPath {
+		t.Fatalf("expected apiPath %s, got %s", expectedApiPath, swaggerModel.ApiPath)
+	}
+
+	expectedModelName := "DataCollectionRuleResource"
+	if swaggerModel.ModelName != expectedModelName {
+		t.Fatalf("expected modelName %s, got %s", expectedModelName, swaggerModel.ModelName)
+	}
+
+	expectedModelSwaggerPathSuffix := "/monitor/resource-manager/Microsoft.Insights/stable/2022-06-01/dataCollectionRules_API.json"
+	if !strings.HasSuffix(swaggerModel.SwaggerPath, expectedModelSwaggerPathSuffix) {
+		t.Fatalf("expected modelSwaggerPath has suffix %s, got %s", expectedModelSwaggerPathSuffix, swaggerModel.SwaggerPath)
 	}
 }

--- a/hcl/parse_test.go
+++ b/hcl/parse_test.go
@@ -55,3 +55,28 @@ func TestParseVariable(t *testing.T) {
 		}
 	}
 }
+
+func TestParseAzureProvider(t *testing.T) {
+	testFileDir := "testdata/"
+
+	tfFiles, err := hcl.FindTfFiles(testFileDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tfFile := range *tfFiles {
+		f, errs := hcl.ParseHclFile(tfFile)
+		if errs != nil {
+			t.Fatal(errs)
+		}
+
+		azureProviders, errs := hcl.ParseAzureProvider(*f)
+		if errs != nil {
+			t.Fatal(errs)
+		}
+
+		for _, ap := range *azureProviders {
+			t.Logf("%+v", ap)
+		}
+	}
+}

--- a/hcl/testdata/test.tf
+++ b/hcl/testdata/test.tf
@@ -6,8 +6,36 @@ terraform {
   }
 }
 
+provider "azurerm" {
+  features {}
+  client_id            = "00000000-0000-0000-0000-000000000000"
+  client_secret        = var.client_secret
+  auxiliary_tenant_ids = ["00000000-0000-0000-0000-000000000000", var.another_tenant_id]
+}
+
 provider "azapi" {
   skip_provider_registration = false
+  auxiliary_tenant_ids       = var.auxiliary_tenant_ids
+  oidc_token                 = var.oidc_token
+}
+
+variable "oidc_token" {
+  sensitive = true
+}
+
+variable "another_tenant_id" {
+  type      = string
+  default   = "00000000-0000-0000-0000-000000000000"
+  sensitive = true
+}
+
+variable "auxiliary_tenant_ids" {
+  default = ["00000000-0000-0000-0000-000000000000"]
+}
+
+variable "client_secret" {
+  type    = string
+  default = "0000000"
 }
 
 variable "resource_name" {


### PR DESCRIPTION
enhance #83 
```sh
armstrong credscan [-v] [-working-dir <path to Terraform configuration files>] [-swagger-repo <path/dir to the swagger files>]
```
option `-swagger` is changed to `-swagger-repo` to differentiate the `-swagger` used in `armstrong test` command which requires specific json file.

cred scan for [`azurerm`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs) and [`azapi`](https://registry.terraform.io/providers/Azure/azapi/latest/docs) provider block and scanning below secret properties, firing error if secret is plain text or the referenced variable has a default or not explicitly set `sensitive=true`:

- auxiliary_tenant_ids
- client_certificate
- client_certificate_password
- client_id
- client_secret
- oidc_request_token
- oidc_token
- subscription_id
- tenant_id

the errors are saved in json/markdown format file, the json is like:
```
{
    "file_name": "/Users/wt/projects/go/armstrong/hcl/testdata/test.tf",
    "name": "azurerm",
    "type": "provider",
    "property_name": "client_id",
    "error_message": "must use variable for secret field",
    "line_number": 9
  }
```