### PR TITLE
fix cred scan to accept reference for secret field

### DIFF
--- a/hcl/testdata/test2.tf
+++ b/hcl/testdata/test2.tf
@@ -1,0 +1,32 @@
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-rg"
+  location = "East US"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa37"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_spring_cloud_service" "test" {
+  name                = "acctest-sc-37"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azapi_resource" "test" {
+  type      = "Microsoft.AppPlatform/spring/storages@2024-01-01-preview"
+  name      = "acctest-ss-37"
+  parent_id = azurerm_spring_cloud_service.test.id
+
+  body = jsonencode({
+    properties = {
+      accountKey  = azurerm_storage_account.test.primary_access_key
+      accountName = azurerm_storage_account.test.name
+      storageType = "StorageAccount"
+    }
+  })
+}


### PR DESCRIPTION
1. fix the bug when a resource body has refered another resource for more than one time.
2. change the secret check logic from (must refer `var`) to (cannot use plain text or refer `local`), in this way referring another resource is accepted like in https://github.com/Azure/armstrong/pull/90/files#diff-c39900c514bdf972da21e4cc112f3caccb17ecb277039bfdffe70dad3a264270R27