### PR TITLE
support specify cache file for credscan index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ armstrong.exe
 
 # test output
 coverage/test_coverage_report*.md
-
+coverage/testdata/index.json

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/azure/armstrong/coverage"
@@ -19,6 +20,10 @@ type testCase struct {
 	apiPath      string
 	rawRequest   []string
 	resourceType string
+}
+
+func normarlizePath(path string) string {
+	return strings.ReplaceAll(path, string(os.PathSeparator), "/")
 }
 
 func TestCoverage_ResourceGroup(t *testing.T) {
@@ -1402,6 +1407,7 @@ func testCoverage(t *testing.T, tc testCase) (*coverage.Model, error) {
 	swaggerModel, err := coverage.GetModelInfoFromIndex(
 		tc.apiPath,
 		tc.apiVersion,
+		"",
 	)
 
 	t.Logf("swaggerModel: %+v", swaggerModel)
@@ -1477,6 +1483,7 @@ func testCredScan(t *testing.T, tc testCase) (*map[string]string, error) {
 	swaggerModel, err := coverage.GetModelInfoFromIndex(
 		tc.apiPath,
 		tc.apiVersion,
+		"",
 	)
 
 	t.Logf("swaggerModel: %+v", swaggerModel)

--- a/coverage/expand.go
+++ b/coverage/expand.go
@@ -2,7 +2,6 @@ package coverage
 
 import (
 	"fmt"
-	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -327,7 +326,7 @@ func SchemaNamePathFromRef(swaggerPath string, ref openapiSpec.Ref) (schemaName 
 		schemaPath = swaggerPath
 	} else {
 		swaggerPath, _ := filepath.Split(swaggerPath)
-		schemaPath, _ = url.JoinPath(swaggerPath, schemaPath)
+		schemaPath = swaggerPath + schemaPath
 	}
 
 	fragments := strings.Split(refUrl.Fragment, "/")

--- a/coverage/expand_test.go
+++ b/coverage/expand_test.go
@@ -119,7 +119,7 @@ func TestExpandAll(t *testing.T) {
 	if strings.HasSuffix(azureRepoDir, "specification") {
 		azureRepoDir += "/"
 	}
-	if !strings.HasSuffix(azureRepoDir, "specification/") {
+	if !strings.HasSuffix(normarlizePath(azureRepoDir), "specification/") {
 		t.Fatalf("AZURE_REST_REPO_DIR must specify the specification folder, e.g., AZURE_REST_REPO_DIR=\"/home/test/go/src/github.com/azure/azure-rest-api-specs/specification/\"")
 	}
 
@@ -207,7 +207,7 @@ func testExpandAll(t *testing.T, azureRepoDir, testResultPath string) result {
 }
 
 func getRefList(t *testing.T) []jsonreference.Ref {
-	index, err := coverage.GetIndex()
+	index, err := coverage.GetIndex("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/coverage/from_local_spec.go
+++ b/coverage/from_local_spec.go
@@ -51,7 +51,7 @@ func GetModelInfoFromLocalSpecFile(resourceId, apiVersion, swaggerPath string) (
 	}
 
 	for pathKey, pathItem := range paths.Paths {
-		if !isPathKeyMatchWithResourceId(pathKey, resourceId) {
+		if !IsPathKeyMatchWithResourceId(pathKey, resourceId) {
 			continue
 		}
 
@@ -95,7 +95,7 @@ func GetModelInfoFromLocalSpecFile(resourceId, apiVersion, swaggerPath string) (
 	return nil, nil
 }
 
-func isPathKeyMatchWithResourceId(pathKey, resourceId string) bool {
+func IsPathKeyMatchWithResourceId(pathKey, resourceId string) bool {
 	pathParts := strings.Split(strings.Trim(pathKey, "/"), "/")
 	resourceIdParts := strings.Split(strings.Trim(resourceId, "/"), "/")
 	i := len(pathParts) - 1

--- a/coverage/from_local_spec_test.go
+++ b/coverage/from_local_spec_test.go
@@ -1,9 +1,11 @@
-package coverage
+package coverage_test
 
 import (
 	"os"
 	"path"
 	"testing"
+
+	"github.com/azure/armstrong/coverage"
 )
 
 func Test_isPathKeyMatchWithResourceId(t *testing.T) {
@@ -35,7 +37,7 @@ func Test_isPathKeyMatchWithResourceId(t *testing.T) {
 	}
 	for _, testcase := range testcases {
 		t.Logf("testcase: %+v", testcase)
-		actual := isPathKeyMatchWithResourceId(testcase.PathKey, testcase.ResourceId)
+		actual := coverage.IsPathKeyMatchWithResourceId(testcase.PathKey, testcase.ResourceId)
 		if actual != testcase.Expected {
 			t.Fatalf("expected %v, got %v", testcase.Expected, actual)
 		}
@@ -51,12 +53,12 @@ func Test_GetModelInfoFromLocalDir(t *testing.T) {
 	testcases := []struct {
 		ResourceId string
 		ApiVersion string
-		Expected   *SwaggerModel
+		Expected   *coverage.SwaggerModel
 	}{
 		{
 			ResourceId: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-resources/providers/Microsoft.Automation/automationAccounts/test-automation-account",
 			ApiVersion: "2022-08-08",
-			Expected: &SwaggerModel{
+			Expected: &coverage.SwaggerModel{
 				ApiPath:     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}",
 				ModelName:   "AutomationAccountCreateOrUpdateParameters",
 				SwaggerPath: path.Join(swaggerPath, "account.json"),
@@ -65,7 +67,7 @@ func Test_GetModelInfoFromLocalDir(t *testing.T) {
 		{
 			ResourceId: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-resources/providers/Microsoft.Automation/automationAccounts/test-automation-account/certificates/test-certificate",
 			ApiVersion: "2022-08-08",
-			Expected: &SwaggerModel{
+			Expected: &coverage.SwaggerModel{
 				ApiPath:     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/certificates/{certificateName}",
 				ModelName:   "CertificateCreateOrUpdateParameters",
 				SwaggerPath: path.Join(swaggerPath, "certificate.json"),
@@ -75,7 +77,7 @@ func Test_GetModelInfoFromLocalDir(t *testing.T) {
 
 	for _, testcase := range testcases {
 		t.Logf("testcase: %+v", testcase.ResourceId)
-		actual, err := GetModelInfoFromLocalDir(testcase.ResourceId, testcase.ApiVersion, swaggerPath)
+		actual, err := coverage.GetModelInfoFromLocalDir(testcase.ResourceId, testcase.ApiVersion, swaggerPath)
 		if err != nil {
 			t.Fatalf("get model info from local dir error: %+v", err)
 		}
@@ -88,7 +90,7 @@ func Test_GetModelInfoFromLocalDir(t *testing.T) {
 		if actual.ModelName != testcase.Expected.ModelName {
 			t.Fatalf("expected modelName %s, got %s", testcase.Expected.ModelName, actual.ModelName)
 		}
-		if actual.SwaggerPath != testcase.Expected.SwaggerPath {
+		if normarlizePath(actual.SwaggerPath) != normarlizePath(testcase.Expected.SwaggerPath) {
 			t.Fatalf("expected swaggerPath %s, got %s", testcase.Expected.SwaggerPath, actual.SwaggerPath)
 		}
 	}

--- a/coverage/index_test.go
+++ b/coverage/index_test.go
@@ -6,13 +6,45 @@ import (
 	"testing"
 
 	"github.com/azure/armstrong/coverage"
+	"github.com/go-openapi/jsonreference"
+	openapispec "github.com/go-openapi/spec"
 )
+
+const indexFilePath = "testdata/index.json"
 
 func TestGetModelInfoFromIndex_DataCollectionRule(t *testing.T) {
 	apiVersion := "2022-06-01"
 	swaggerModel, err := coverage.GetModelInfoFromIndex(
 		"/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-resources/providers/Microsoft.Insights/dataCollectionRules/testDCR",
 		apiVersion,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("get model info from index error: %+v", err)
+	}
+
+	expectedApiPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Insights/dataCollectionRules/{dataCollectionRuleName}"
+	if swaggerModel.ApiPath != expectedApiPath {
+		t.Fatalf("expected apiPath %s, got %s", expectedApiPath, swaggerModel.ApiPath)
+	}
+
+	expectedModelName := "DataCollectionRuleResource"
+	if swaggerModel.ModelName != expectedModelName {
+		t.Fatalf("expected modelName %s, got %s", expectedModelName, swaggerModel.ModelName)
+	}
+
+	expectedModelSwaggerPath := "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/monitor/resource-manager/Microsoft.Insights/stable/2022-06-01/dataCollectionRules_API.json"
+	if swaggerModel.SwaggerPath != expectedModelSwaggerPath {
+		t.Fatalf("expected modelSwaggerPath %s, got %s", expectedModelSwaggerPath, swaggerModel.SwaggerPath)
+	}
+}
+
+func TestGetModelInfoFromIndexWithCache_DataCollectionRule(t *testing.T) {
+	apiVersion := "2022-06-01"
+	swaggerModel, err := coverage.GetModelInfoFromIndex(
+		"/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-resources/providers/Microsoft.Insights/dataCollectionRules/testDCR",
+		apiVersion,
+		indexFilePath,
 	)
 	if err != nil {
 		t.Fatalf("get model info from index error: %+v", err)
@@ -39,6 +71,7 @@ func TestGetModelInfoFromIndex_DeviceSecurityGroups(t *testing.T) {
 	swaggerModel, err := coverage.GetModelInfoFromIndex(
 		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SampleRG/providers/Microsoft.Devices/iotHubs/sampleiothub/providers/Microsoft.Security/deviceSecurityGroups/samplesecuritygroup",
 		apiVersion,
+		"",
 	)
 	if err != nil {
 		t.Fatalf("get model info from index error: %+v", err)
@@ -62,7 +95,7 @@ func TestGetModelInfoFromIndex_DeviceSecurityGroups(t *testing.T) {
 
 func TestGetModelInfoFromIndexWithType_DataCollectionRule(t *testing.T) {
 	azapiResourceType := "Microsoft.Insights/dataCollectionRules@2022-06-01"
-	swaggerModel, err := coverage.GetModelInfoFromIndexWithType(azapiResourceType)
+	swaggerModel, err := coverage.GetModelInfoFromIndexWithType(azapiResourceType, "")
 	if err != nil {
 		t.Fatalf("get model info from index error: %+v", err)
 	}
@@ -73,9 +106,27 @@ func TestGetModelInfoFromIndexWithType_DataCollectionRule(t *testing.T) {
 	}
 }
 
+func TestGetModelInfoFromIndexWithTypeWithCache_DataCollectionRule(t *testing.T) {
+	azapiResourceType := "Microsoft.Insights/dataCollectionRules@2022-06-01"
+	swaggerModel, err := coverage.GetModelInfoFromIndexWithType(azapiResourceType, indexFilePath)
+	if err != nil {
+		t.Fatalf("get model info from index error: %+v", err)
+	}
+
+	expectedApiPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Insights/dataCollectionRules/{dataCollectionRuleName}"
+	if swaggerModel.ApiPath != expectedApiPath {
+		t.Fatalf("expected apiPath %s, got %s", expectedApiPath, swaggerModel.ApiPath)
+	}
+
+	_, err = coverage.GetModelInfoFromIndexWithType(azapiResourceType, indexFilePath)
+	if err != nil {
+		t.Fatalf("get model info from index error: %+v", err)
+	}
+}
+
 func TestGetModelInfoFromIndexWithType_DeviceSecurityGroups(t *testing.T) {
 	azapiResourceType := "Microsoft.Security/deviceSecurityGroups@2019-08-01"
-	swaggerModel, err := coverage.GetModelInfoFromIndexWithType(azapiResourceType)
+	swaggerModel, err := coverage.GetModelInfoFromIndexWithType(azapiResourceType, "")
 	if err != nil {
 		t.Fatalf("get model info from index error: %+v", err)
 	}
@@ -97,6 +148,7 @@ func TestGetModelInfoFromLocalIndex_DataCollectionRule(t *testing.T) {
 		"/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-resources/providers/Microsoft.Insights/dataCollectionRules/testDCR",
 		apiVersion,
 		azureRepoDir,
+		"",
 	)
 	if err != nil {
 		t.Fatalf("get model info from index error: %+v", err)
@@ -113,7 +165,68 @@ func TestGetModelInfoFromLocalIndex_DataCollectionRule(t *testing.T) {
 	}
 
 	expectedModelSwaggerPathSuffix := "/monitor/resource-manager/Microsoft.Insights/stable/2022-06-01/dataCollectionRules_API.json"
-	if !strings.HasSuffix(swaggerModel.SwaggerPath, expectedModelSwaggerPathSuffix) {
+	if !strings.HasSuffix(normarlizePath(swaggerModel.SwaggerPath), expectedModelSwaggerPathSuffix) {
 		t.Fatalf("expected modelSwaggerPath has suffix %s, got %s", expectedModelSwaggerPathSuffix, swaggerModel.SwaggerPath)
+	}
+}
+
+func TestGetModelInfoFromLocalIndexWithCache_DataCollectionRule(t *testing.T) {
+	azureRepoDir := os.Getenv("AZURE_REST_REPO_DIR")
+	if azureRepoDir == "" {
+		t.Skip("AZURE_REST_REPO_DIR is not set")
+	}
+
+	apiVersion := "2022-06-01"
+	swaggerModel, err := coverage.GetModelInfoFromLocalIndex(
+		"/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-resources/providers/Microsoft.Insights/dataCollectionRules/testDCR",
+		apiVersion,
+		azureRepoDir,
+		indexFilePath,
+	)
+	if err != nil {
+		t.Fatalf("get model info from index error: %+v", err)
+	}
+
+	expectedApiPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Insights/dataCollectionRules/{dataCollectionRuleName}"
+	if swaggerModel.ApiPath != expectedApiPath {
+		t.Fatalf("expected apiPath %s, got %s", expectedApiPath, swaggerModel.ApiPath)
+	}
+
+	expectedModelName := "DataCollectionRuleResource"
+	if swaggerModel.ModelName != expectedModelName {
+		t.Fatalf("expected modelName %s, got %s", expectedModelName, swaggerModel.ModelName)
+	}
+
+	expectedModelSwaggerPathSuffix := "/monitor/resource-manager/Microsoft.Insights/stable/2022-06-01/dataCollectionRules_API.json"
+	if !strings.HasSuffix(normarlizePath(swaggerModel.SwaggerPath), expectedModelSwaggerPathSuffix) {
+		t.Fatalf("expected modelSwaggerPath has suffix %s, got %s", expectedModelSwaggerPathSuffix, swaggerModel.SwaggerPath)
+	}
+
+	_, err = coverage.GetModelInfoFromLocalIndex(
+		"/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-resources/providers/Microsoft.Insights/dataCollectionRules/testDCR",
+		apiVersion,
+		azureRepoDir,
+		indexFilePath,
+	)
+	if err != nil {
+		t.Fatalf("get model info from index error: %+v", err)
+	}
+
+}
+
+func TestGetModelInfoFromIndexRef(t *testing.T) {
+	if os.PathSeparator != '\\' {
+		t.Skip("this test is only for windows with backslashes(\\) as the file path seperator")
+	}
+
+	azureRepoDir := os.Getenv("AZURE_REST_REPO_DIR")
+	if azureRepoDir == "" {
+		t.Skip("AZURE_REST_REPO_DIR is not set")
+	}
+
+	pathRef := jsonreference.MustCreateRef("monitor%5Cresource-manager%5CMicrosoft.Insights%5Cstable%5C2021-08-01%5CscheduledQueryRule_API.json#/paths/~1subscriptions~1%7BsubscriptionId%7D~1resourceGroups~1%7BresourceGroupName%7D~1providers~1Microsoft.Insights~1scheduledQueryRules~1%7BruleName%7D/put")
+	_, err := coverage.GetModelInfoFromIndexRef(openapispec.Ref{Ref: pathRef}, azureRepoDir)
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/coverage/report.go
+++ b/coverage/report.go
@@ -28,7 +28,7 @@ func (c *CoverageReport) AddCoverageFromState(resourceId, resourceType string, j
 		swaggerModel = swaggerModelFromLocal
 	}
 	if swaggerModel == nil {
-		swaggerModelFromIndex, err := GetModelInfoFromIndex(resourceId, apiVersion)
+		swaggerModelFromIndex, err := GetModelInfoFromIndex(resourceId, apiVersion, "")
 		if err != nil {
 			return fmt.Errorf("error find the path for %s from index: %+v", resourceId, err)
 		}

--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,8 @@ armstrong credscan
 Supported options:
 1. `-working-dir`: Specify the working directory containing Terraform config files, default is current directory.
 2. `-swagger-repo`: Specify the swagger repo path used to match credentials, omit this will use the online swagger repo.
-2. `-v`: Enable verbose mode, default is false.
+3. `-swagger-index-file`: Specify the path to the swagger index file, omit this will use the online swagger index file or locally build index. If the specified file is not found, the downloaded or built index will be saved in the provided file.
+4. `-v`: Enable verbose mode, default is false.
 
 Armstrong also output different kinds of reports:
 1. `errors.json`: A json report which contains scan errors.


### PR DESCRIPTION
1. fix index resolve issue when running in windows powershell with path seperator (`\`)
2. add `-swagger-index-file` option for `armstrong credscan`, omit this will use the online swagger index file or locally build index, and if not exists, downloaded or built index will be saved to the file.