### PR TITLE
fix coverage for mismatch prop

### DIFF
--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -49,7 +49,7 @@ func (m *Model) CredScan(root interface{}, secrets map[string]string) {
 
 	case []interface{}:
 		if m.Item == nil {
-			logrus.Errorf("unexpected array in %s\n", m.Identifier)
+			logrus.Errorf("unexpected array in %s", m.Identifier)
 		}
 
 		for _, item := range value {
@@ -82,7 +82,7 @@ func (m *Model) CredScan(root interface{}, secrets map[string]string) {
 							break Loop
 						}
 					}
-					logrus.Errorf("unexpected variant %s in %s\n", v.(string), m.Identifier)
+					logrus.Errorf("unexpected variant %s in %s", v.(string), m.Identifier)
 				}
 			}
 		}
@@ -91,14 +91,14 @@ func (m *Model) CredScan(root interface{}, secrets map[string]string) {
 			for k, v := range value {
 				if m.Properties == nil {
 					if !m.HasAdditionalProperties {
-						logrus.Warnf("unexpected key %s in %s\n", k, m.Identifier)
+						logrus.Errorf("unexpected key %s in %s", k, m.Identifier)
 					}
-					return
+					continue
 				}
 				if _, ok := (*m.Properties)[k]; !ok {
 					if !m.HasAdditionalProperties {
-						logrus.Warnf("unexpected key %s in %s\n", k, m.Identifier)
-						return
+						logrus.Errorf("unexpected key %s in %s", k, m.Identifier)
+						continue
 					}
 				}
 				if (*m.Properties)[k].IsSecret {
@@ -128,7 +128,7 @@ func (m *Model) MarkCovered(root interface{}) {
 		if m.Enum != nil {
 			strValue := fmt.Sprintf("%v", value)
 			if _, ok := (*m.Enum)[strValue]; !ok {
-				logrus.Warnf("unexpected enum %s in %s\n", value, m.Identifier)
+				logrus.Errorf("unexpected enum %s in %s", value, m.Identifier)
 			}
 
 			(*m.Enum)[strValue] = true
@@ -136,7 +136,7 @@ func (m *Model) MarkCovered(root interface{}) {
 
 	case bool:
 		if m.Bool == nil {
-			logrus.Errorf("unexpected bool %v in %v\n", value, m.Identifier)
+			logrus.Errorf("unexpected bool %v in %v", value, m.Identifier)
 		}
 		(*m.Bool)[strconv.FormatBool(value)] = true
 
@@ -144,7 +144,7 @@ func (m *Model) MarkCovered(root interface{}) {
 
 	case []interface{}:
 		if m.Item == nil {
-			logrus.Errorf("unexpected array in %s\n", m.Identifier)
+			logrus.Errorf("unexpected array in %s", m.Identifier)
 		}
 
 		for _, item := range value {
@@ -181,7 +181,7 @@ func (m *Model) MarkCovered(root interface{}) {
 							break Loop
 						}
 					}
-					logrus.Errorf("unexpected variant %s in %s\n", v.(string), m.Identifier)
+					logrus.Errorf("unexpected variant %s in %s", v.(string), m.Identifier)
 				}
 			}
 		}
@@ -190,14 +190,14 @@ func (m *Model) MarkCovered(root interface{}) {
 			for k, v := range value {
 				if m.Properties == nil {
 					if !m.HasAdditionalProperties {
-						logrus.Warnf("unexpected key %s in %s\n", k, m.Identifier)
+						logrus.Errorf("unexpected key %s in %s", k, m.Identifier)
 					}
-					return
+					continue
 				}
 				if _, ok := (*m.Properties)[k]; !ok {
 					if !m.HasAdditionalProperties {
-						logrus.Warnf("unexpected key %s in %s\n", k, m.Identifier)
-						return
+						logrus.Errorf("unexpected key %s in %s", k, m.Identifier)
+						continue
 					}
 				}
 				(*m.Properties)[k].MarkCovered(v)

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -65,6 +65,69 @@ func TestCoverage_ResourceGroup(t *testing.T) {
 	}
 }
 
+func TestCoverage_HealthcareDicom(t *testing.T) {
+	tc := testCase{
+		name:         "HealthcareApisDicom",
+		resourceType: "Microsoft.HealthcareApis/workspaces/dicomservices@2024-03-31",
+		apiVersion:   "2024-03-31",
+		apiPath:      "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/rgName/providers/Microsoft.HealthcareApis/workspaces/workspaceName/dicomservices/dicomServiceName",
+		// bulkImportConfiguration property not in swagger
+		rawRequest: []string{
+			`{
+    "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+            "${azurerm_user_assigned_identity.userAssignedIdentity.id}": {}
+        }
+    },
+    "location": "westus",
+    "properties": {
+        "corsConfiguration": {
+            "allowCredentials": false,
+            "headers": [
+                "*"
+            ],
+            "maxAge": 1440,
+            "methods": [
+                "DELETE",
+                "GET",
+                "OPTIONS",
+                "PATCH",
+                "POST",
+                "PUT"
+            ],
+            "origins": [
+                "*"
+            ]
+        },
+        "bulkImportConfiguration": {
+            "enabled": false
+        },
+        "enableDataPartitions": false,
+        "encryption": {
+            "customerManagedKeyEncryption": {
+                "keyEncryptionKeyUrl": "https://${azapi_resource.vault.name}.vault.azure.net/keys/${azurerm_key_vault_key.key.name}/${azurerm_key_vault_key.key.version}"
+            }
+        },
+        "storageConfiguration": {
+            "fileSystemName": "fileSystemName",
+            "storageResourceId": "${azapi_resource.storageAccount.id}"
+        }
+    }
+}`,
+		},
+	}
+
+	model, err := testCoverage(t, tc)
+	if err != nil {
+		t.Fatalf("process coverage: %+v", err)
+	}
+
+	if model.CoveredCount != 12 {
+		t.Fatalf("expected CoveredCount 12, got %d", model.CoveredCount)
+	}
+}
+
 func TestCoverage_MachineLearningServicesWorkspacesJobs(t *testing.T) {
 	tc := testCase{
 		name:         "MachineLearningServicesWorkspacesJobs",
@@ -1455,11 +1518,11 @@ func testCoverage(t *testing.T, tc testCase) (*coverage.Model, error) {
 		return nil, fmt.Errorf("expand model: %+v", err)
 	}
 
-	out, err := json.MarshalIndent(model, "", "\t")
-	if err != nil {
-		t.Error(err)
-	}
-	t.Logf("expand model %s", string(out))
+	//out, err := json.MarshalIndent(model, "", "\t")
+	//if err != nil {
+	//	t.Error(err)
+	//}
+	//t.Logf("expand model %s", string(out))
 
 	for _, rq := range tc.rawRequest {
 		request := map[string]interface{}{}
@@ -1473,11 +1536,11 @@ func testCoverage(t *testing.T, tc testCase) (*coverage.Model, error) {
 
 	model.CountCoverage()
 
-	out, err = json.MarshalIndent(model, "", "\t")
-	if err != nil {
-		t.Error(err)
-	}
-	t.Logf("coverage model %s", string(out))
+	//out, err = json.MarshalIndent(model, "", "\t")
+	//if err != nil {
+	//	t.Error(err)
+	//}
+	//t.Logf("coverage model %s", string(out))
 
 	coverageReport := coverage.CoverageReport{
 		Coverages: map[coverage.ArmResource]*coverage.Model{


### PR DESCRIPTION
if there is property used but it is not included in swagger, the coverage report might skip some props
regards the property not included in swagger, there will be error message in stdout:
```
time="2024-06-18T05:45:48Z" level=error msg="unexpected key bulkImportConfiguration in #.properties"
```
coverage report:
before:

![image](https://github.com/Azure/armstrong/assets/104055472/d5a13364-bff6-48ee-ad9a-c3e4b132e9e1)

after:

![image](https://github.com/Azure/armstrong/assets/104055472/20b6704a-f63e-44af-a3b2-d67c1f3cec4d)

