### PR TITLE
fix mockResourceIDFromType for special resource types

### DIFF
--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -1264,7 +1264,7 @@ func TestCoverage_DataFactoryPipelines(t *testing.T) {
 		resourceType:         "Microsoft.DataFactory/factories/pipelines@2018-06-01",
 		method:               "PUT",
 		expectedCoveredCount: 13,
-		expectedTotalCount:   7239,
+		expectedTotalCount:   7243,
 		apiPath:              "/subscriptions/12345678-1234-1234-1234-12345678abc/resourceGroups/exampleResourceGroup/providers/Microsoft.DataFactory/factories/exampleFactoryName/pipelines/examplePipeline",
 		rawRequest: []string{
 			`{
@@ -1362,7 +1362,7 @@ func TestCoverage_DataFactoryLinkedServices(t *testing.T) {
 		resourceType:         "Microsoft.DataFactory/factories/linkedServices@2018-06-01",
 		method:               "PUT",
 		expectedCoveredCount: 3,
-		expectedTotalCount:   3450,
+		expectedTotalCount:   3470,
 		apiPath:              "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/rg1/providers/Microsoft.DataFactory/factories/factory1/linkedServices/linked",
 		rawRequest: []string{
 			`{

--- a/coverage/index.go
+++ b/coverage/index.go
@@ -296,15 +296,28 @@ func readZipFile(zf *zip.File) ([]byte, error) {
 
 func MockResourceIDFromType(azapiResourceType string) (string, string) {
 	const (
-		managementGroupId = "/providers/Microsoft.Management/managementGroups/group1"
+		managementGroupId = "/providers/Microsoft.Management"
 		subscritionSeg    = "/subscriptions/00000000-0000-0000-0000-000000000000"
 		resourceGroupSeg  = "resourceGroups/rg"
 	)
+
 	resourceType := strings.Split(azapiResourceType, "@")[0]
 	apiVersion := strings.Split(azapiResourceType, "@")[1]
 	resourceProvider := strings.Split(resourceType, "/")[0]
 	rTypes := strings.Split(resourceType, "/")[1:]
 	typeIds := strings.Join(rTypes, "/xxx/") + "/xxx"
+
+	if strings.HasPrefix(strings.ToLower(resourceType), strings.ToLower("Microsoft.Management/managementGroups")) {
+		return fmt.Sprintf("%s/%s", managementGroupId, typeIds), apiVersion
+	}
+
+	if strings.EqualFold(resourceType, "Microsoft.Resources/subscriptions") {
+		return subscritionSeg, apiVersion
+	}
+
+	if strings.EqualFold(resourceType, "Microsoft.Resources/resourceGroups") {
+		return fmt.Sprintf("%s/%s", subscritionSeg, resourceGroupSeg), apiVersion
+	}
 
 	return fmt.Sprintf("%s/%s/providers/%s/%s", subscritionSeg, resourceGroupSeg, resourceProvider, typeIds), apiVersion
 }

--- a/coverage/index_test.go
+++ b/coverage/index_test.go
@@ -217,7 +217,6 @@ func TestGetModelInfoFromLocalIndexWithCache_DataCollectionRule(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get model info from index error: %+v", err)
 	}
-
 }
 
 func TestGetModelInfoFromIndexRef(t *testing.T) {
@@ -234,5 +233,56 @@ func TestGetModelInfoFromIndexRef(t *testing.T) {
 	_, err := coverage.GetModelInfoFromIndexRef(openapispec.Ref{Ref: pathRef}, azureRepoDir)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestMockResourceIDFromType(t *testing.T) {
+	cases := []struct {
+		Type            string
+		Expected        string
+		ExpectedVersion string
+	}{
+		{
+			Type:            "Microsoft.Insights/dataCollectionRules@2022-06-01",
+			Expected:        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/dataCollectionRules/xxx",
+			ExpectedVersion: "2022-06-01",
+		},
+		{
+			Type:            "Microsoft.Resources/resourceGroups@2024-03-01",
+			Expected:        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg",
+			ExpectedVersion: "2024-03-01",
+		},
+		{
+			Type:            "Microsoft.Resources/subscriptions@2024-03-01",
+			Expected:        "/subscriptions/00000000-0000-0000-0000-000000000000",
+			ExpectedVersion: "2024-03-01",
+		},
+		{
+			Type:            "Microsoft.Management/managementGroups@2021-04-01",
+			Expected:        "/providers/Microsoft.Management/managementGroups/xxx",
+			ExpectedVersion: "2021-04-01",
+		},
+		{
+			Type:            "Microsoft.Management/managementGroups/subscriptions@2021-04-01",
+			Expected:        "/providers/Microsoft.Management/managementGroups/xxx/subscriptions/xxx",
+			ExpectedVersion: "2021-04-01",
+		},
+		{
+			Type:            "Microsoft.Network/virtualNetworks/subnets@2024-03-01",
+			Expected:        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/xxx/subnets/xxx",
+			ExpectedVersion: "2024-03-01",
+		},
+	}
+	for _, tc := range cases {
+		resourceType, version := coverage.MockResourceIDFromType(tc.Type)
+		if tc.Expected != resourceType {
+			t.Fatalf("TestMockResourceIDFromType Type: %s, Expected: %s, Got: %s ", tc.Type, tc.Expected, resourceType)
+			return
+		}
+
+		if tc.ExpectedVersion != version {
+			t.Fatalf("TestMockResourceIDFromType Type: %s, ExpectedVersion: %s, Got: %s ", tc.Type, tc.ExpectedVersion, version)
+			return
+		}
 	}
 }


### PR DESCRIPTION
fix the issue that `mockResourceIDFromType` generate wrong ID for resource type `Microsoft.Resources/resourceGroups`

<img width="637" alt="image" src="https://github.com/user-attachments/assets/f3b68c9b-a191-4c00-bccf-b62966a081c4">
